### PR TITLE
Add CLI flags for selective product checking

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: super-linter/super-linter@v6
+      - uses: super-linter/super-linter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_RUST_2015: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Cargo workspace with a main binary and product-specific library crates:
 
-- **Main binary** (`src/main.rs`): 
+- **Main binary** (`src/main.rs`):
   - CLI interface using `clap` with derive macros
   - Orchestrates concurrent checks using `futures::join!`
   - Selective product checking via `--jb`, `--mongo`, `--chrome` flags (combinable)
@@ -97,7 +97,7 @@ cargo test --all
 ## CI/CD
 
 GitHub Actions runs on push/PR to main:
-1. **Rust workflow** (`rust.yml`): 
+1. **Rust workflow** (`rust.yml`):
    - Format check with `cargo fmt -- --check`
    - Build with `cargo build --verbose`
    - Clippy with `cargo clippy -- -D warnings`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`checkupdates-external` is a Rust CLI tool that checks for updates from external (non-Arch) repositories for packages available in the Arch Linux AUR. It outputs updates in the format: `<package> <current_ver> -> <new_version>`.
+
+## Architecture
+
+This is a Cargo workspace with a main binary and product-specific library crates:
+
+- **Main binary** (`src/main.rs`): Orchestrates concurrent checks across all products using `futures::join!`
+- **Product crates** (`crates/*/`): Each handles a specific external source (Chrome, Edge, JetBrains, MongoDB, TeamViewer)
+- **Shared crates**:
+  - `crates/yum/`: Common YUM repository parsing functionality
+  - `crates/aur/`: Centralized AUR package fetching
+
+Each product crate follows this pattern:
+- `lib.rs`: Re-exports public API
+- `fetch.rs`: Async functions to fetch version information
+- `model.rs`: Data structures (when needed)
+- `print.rs`: Output formatting (when needed)
+
+## Essential Commands
+
+```bash
+# Building
+cargo build                    # Debug build
+cargo build --release         # Release build
+
+# Code Quality
+cargo fmt                     # Format code
+cargo fmt -- --check         # Check formatting
+cargo clippy -- -D warnings  # Lint with warnings as errors
+
+# Running
+cargo run                    # Run debug version
+./target/release/checkupdates-external  # Run release binary
+```
+
+## Key Development Patterns
+
+### Adding a new product checker
+
+1. Create new crate under `crates/` with standard structure
+2. Add to workspace members in root `Cargo.toml`
+3. Implement async fetch function returning `Vec<(name, current_ver, new_ver)>`
+4. Add check function call in `main.rs` using `futures::join!`
+
+### Working with versions
+
+- **YUM-based products** (Chrome, Edge, MongoDB, TeamViewer): Use shared `yum` crate for XML parsing
+- **JetBrains**: Custom XML parsing from updates endpoint
+- Always fetch both upstream and AUR versions for comparison
+
+### Async operations
+
+- All network calls use `reqwest` with `Result<T, reqwest::Error>`
+- Main uses Tokio runtime (`#[tokio::main]`)
+- Concurrent execution via `futures::join!` for all product checks
+
+### Error handling
+
+- Network errors bubble up through Result chain
+- Main uses `.expect()` for critical failures
+- No custom error types - relies on `reqwest::Error`
+
+## Dependencies
+
+Core dependencies across crates:
+- `reqwest` (with features: ["gzip", "json"])
+- `tokio` (async runtime)
+- `serde` + `serde_json` + `serde-xml-rs` (serialization)
+- `libflate` (gzip decompression)
+- `itertools` (utility functions)
+
+## CI/CD
+
+GitHub Actions runs on push/PR to main:
+1. **Rust workflow**: Format check → Build → Clippy
+2. **Super-linter**: General code quality checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Cargo workspace with a main binary and product-specific library crates:
 
-- **Main binary** (`src/main.rs`): Orchestrates concurrent checks across all products using `futures::join!`
-- **Product crates** (`crates/*/`): Each handles a specific external source (Chrome, Edge, JetBrains, MongoDB, TeamViewer)
+- **Main binary** (`src/main.rs`): 
+  - CLI interface using `clap` with derive macros
+  - Orchestrates concurrent checks using `futures::join!`
+  - Selective product checking via `--jb`, `--mongo`, `--chrome` flags (combinable)
+  - `--all` flag to show all packages even when versions match
+
+- **Product crates** (`crates/*/`): Each handles a specific external source
+  - `chrome/`: Google Chrome (stable, beta, dev, canary)
+  - `edge/`: Microsoft Edge (stable, beta, dev)
+  - `jetbrains/`: All JetBrains IDEs (stable and EAP channels)
+  - `mongodb/`: MongoDB packages
+  - `teamviewer/`: TeamViewer
+
 - **Shared crates**:
-  - `crates/yum/`: Common YUM repository parsing functionality
+  - `crates/yum/`: Common YUM repository XML parsing
   - `crates/aur/`: Centralized AUR package fetching
 
 Each product crate follows this pattern:
@@ -35,8 +46,15 @@ cargo fmt -- --check         # Check formatting
 cargo clippy -- -D warnings  # Lint with warnings as errors
 
 # Running
-cargo run                    # Run debug version
-./target/release/checkupdates-external  # Run release binary
+cargo run                    # Check all products
+cargo run -- --jb            # JetBrains only
+cargo run -- --mongo         # MongoDB only
+cargo run -- --chrome        # Chrome only
+cargo run -- --jb --chrome   # Multiple products
+cargo run -- --all           # Show all packages (even matching versions)
+
+# Testing (currently no tests exist)
+cargo test --all
 ```
 
 ## Key Development Patterns
@@ -44,39 +62,43 @@ cargo run                    # Run debug version
 ### Adding a new product checker
 
 1. Create new crate under `crates/` with standard structure
-2. Add to workspace members in root `Cargo.toml`
-3. Implement async fetch function returning `Vec<(name, current_ver, new_ver)>`
-4. Add check function call in `main.rs` using `futures::join!`
+2. Add to workspace in root `Cargo.toml`: `newproduct = { path = "crates/newproduct" }`
+3. For YUM-based products:
+   - Use `yum::fetch_yum_updates()` with the repository URL
+   - Return `Vec<YumUpdate>`
+4. For custom formats:
+   - Implement custom parsing with serde
+   - Follow JetBrains pattern for complex XML
+5. Add check function in `main.rs` following existing pattern
+6. Add to concurrent execution in main's `join!` or futures vector
+7. Optionally add CLI flag for selective checking
 
-### Working with versions
+### XML Parsing with serde-xml-rs 0.8.x
 
-- **YUM-based products** (Chrome, Edge, MongoDB, TeamViewer): Use shared `yum` crate for XML parsing
-- **JetBrains**: Custom XML parsing from updates endpoint
-- Always fetch both upstream and AUR versions for comparison
+**Important**: XML attributes must use `@` prefix in serde rename:
+```rust
+#[serde(rename = "@name")]    // For attributes
+#[serde(rename = "element")]   // For nested elements
+```
 
-### Async operations
+### Version handling
 
-- All network calls use `reqwest` with `Result<T, reqwest::Error>`
-- Main uses Tokio runtime (`#[tokio::main]`)
-- Concurrent execution via `futures::join!` for all product checks
+- AUR versions include release suffix (e.g., "1.2.3-1")
+- Upstream versions are typically clean (e.g., "1.2.3")
+- JetBrains uses complex build numbers requiring special parsing
+- Pre-release versions (containing '~') are filtered out
 
 ### Error handling
 
-- Network errors bubble up through Result chain
-- Main uses `.expect()` for critical failures
-- No custom error types - relies on `reqwest::Error`
-
-## Dependencies
-
-Core dependencies across crates:
-- `reqwest` (with features: ["gzip", "json"])
-- `tokio` (async runtime)
-- `serde` + `serde_json` + `serde-xml-rs` (serialization)
-- `libflate` (gzip decompression)
-- `itertools` (utility functions)
+- All async functions return `Result<T, reqwest::Error>`
+- No custom error types
+- Critical failures use `.expect()` with descriptive messages
 
 ## CI/CD
 
 GitHub Actions runs on push/PR to main:
-1. **Rust workflow**: Format check → Build → Clippy
-2. **Super-linter**: General code quality checks
+1. **Rust workflow** (`rust.yml`): 
+   - Format check with `cargo fmt -- --check`
+   - Build with `cargo build --verbose`
+   - Clippy with `cargo clippy -- -D warnings`
+2. **Super-linter** (`linter.yml`): General code quality (Rust linters disabled)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is a Cargo workspace with a main binary and product-specific library crates:
 
 - **Main binary** (`src/main.rs`):
+
   - CLI interface using `clap` with derive macros
   - Orchestrates concurrent checks using `futures::join!`
   - Selective product checking via `--jb`, `--mongo`, `--chrome` flags (combinable)
   - `--all` flag to show all packages even when versions match
 
 - **Product crates** (`crates/*/`): Each handles a specific external source
+
   - `chrome/`: Google Chrome (stable, beta, dev, canary)
   - `edge/`: Microsoft Edge (stable, beta, dev)
   - `jetbrains/`: All JetBrains IDEs (stable and EAP channels)
@@ -28,7 +30,8 @@ This is a Cargo workspace with a main binary and product-specific library crates
   - `crates/aur/`: Centralized AUR package fetching
 
 Each product crate follows this pattern:
-- `lib.rs`: Re-exports public API
+
+- `lib.rs`: Reexports public API
 - `fetch.rs`: Async functions to fetch version information
 - `model.rs`: Data structures (when needed)
 - `print.rs`: Output formatting (when needed)
@@ -76,6 +79,7 @@ cargo test --all
 ### XML Parsing with serde-xml-rs 0.8.x
 
 **Important**: XML attributes must use `@` prefix in serde rename:
+
 ```rust
 #[serde(rename = "@name")]    // For attributes
 #[serde(rename = "element")]   // For nested elements
@@ -97,6 +101,7 @@ cargo test --all
 ## CI/CD
 
 GitHub Actions runs on push/PR to main:
+
 1. **Rust workflow** (`rust.yml`):
    - Format check with `cargo fmt -- --check`
    - Build with `cargo build --verbose`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`checkupdates-external` is a Rust CLI tool that checks for updates from external (non-Arch) repositories for packages available in the Arch Linux AUR. It outputs updates in the format: `<package> <current_ver> -> <new_version>`.
+`checkupdates-external` is a Rust command-line tool that checks for updates from external (non-Arch) repositories for packages available in the Arch Linux AUR. It outputs updates in the format: `<package> <current_ver> -> <new_version>`.
 
 ## Architecture
 
@@ -86,7 +86,7 @@ cargo test --all
 - AUR versions include release suffix (e.g., "1.2.3-1")
 - Upstream versions are typically clean (e.g., "1.2.3")
 - JetBrains uses complex build numbers requiring special parsing
-- Pre-release versions (containing '~') are filtered out
+- Prerelease versions (containing '~') are filtered out
 
 ### Error handling
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -42,10 +42,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "async-compression"
-version = "0.4.22"
+name = "anstream"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
 dependencies = [
  "flate2",
  "futures-core",
@@ -77,9 +127,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -87,7 +137,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -98,15 +148,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytes"
@@ -116,9 +166,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "shlex",
 ]
@@ -135,6 +185,7 @@ version = "0.1.0"
 dependencies = [
  "aur",
  "chrome",
+ "clap",
  "edge",
  "futures",
  "jetbrains",
@@ -153,6 +204,52 @@ dependencies = [
  "reqwest",
  "yum",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -237,9 +334,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -253,9 +350,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -382,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -393,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -411,9 +508,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -440,9 +537,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -506,11 +609,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -539,41 +641,48 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -583,30 +692,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -614,65 +703,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -688,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -703,7 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -711,6 +787,22 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -785,15 +877,15 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -828,13 +920,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -879,10 +971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -912,9 +1010,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -924,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -934,15 +1032,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -970,6 +1068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,18 +1102,18 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "async-compression",
  "base64",
@@ -1030,22 +1137,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -1056,7 +1162,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1076,9 +1182,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -1089,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1101,25 +1207,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1128,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1193,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "serde-xml-rs"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ef8209566c27b96b10a096e25abc534e08e9bbbcf8e444b92640f1416dd1c6"
+checksum = "53630160a98edebde0123eb4dfd0fce6adff091b2305db3154a9e920206eb510"
 dependencies = [
  "log",
  "serde",
@@ -1264,15 +1364,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1285,6 +1385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,9 +1398,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1312,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1353,12 +1459,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1386,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1396,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1445,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1467,6 +1573,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1495,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1532,16 +1656,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"
@@ -1668,29 +1792,29 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -1701,7 +1825,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1710,7 +1834,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1719,30 +1843,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1752,22 +1860,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1776,22 +1872,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1800,22 +1884,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1824,22 +1896,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -1851,16 +1911,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xml-rs"
@@ -1870,9 +1924,9 @@ checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1882,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1907,18 +1961,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1953,10 +2007,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1965,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ mongodb = { path = "crates/mongodb" }
 teamviewer = { path = "crates/teamviewer" }
 yum = { path = "crates/yum" }
 
-futures = "0.3.31"
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
-tokio = { version = "1.44.2", features = ["full"] }
+clap = { version = "4.5", features = ["derive"] }
+futures = "0.3"
+reqwest = { version = "0.12", features = ["gzip", "json"] }
+tokio = { version = "1.45", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ teamviewer = { path = "crates/teamviewer" }
 yum = { path = "crates/yum" }
 
 clap = { version = "4.5", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.31"
 reqwest = { version = "0.12.19", features = ["gzip", "json"] }
 tokio = { version = "1.45", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ teamviewer = { path = "crates/teamviewer" }
 yum = { path = "crates/yum" }
 
 clap = { version = "4.5", features = ["derive"] }
-futures = "0.3"
-reqwest = { version = "0.12", features = ["gzip", "json"] }
+futures = "0.3.21"
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }
 tokio = { version = "1.45", features = ["full"] }

--- a/crates/aur/Cargo.toml
+++ b/crates/aur/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.31"
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/chrome/Cargo.toml
+++ b/crates/chrome/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 aur = { path = "../aur" }
 yum = { path = "../yum" }
 
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 aur = { path = "../aur" }
 yum = { path = "../yum" }
 
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }

--- a/crates/jetbrains/Cargo.toml
+++ b/crates/jetbrains/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 [dependencies]
 aur = { path = "../aur" }
 
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }
 serde = { version = "1.0.219", features = ["derive"] }
-serde-xml-rs = "0.7.0"
+serde-xml-rs = "0.8.1"

--- a/crates/jetbrains/src/model.rs
+++ b/crates/jetbrains/src/model.rs
@@ -2,14 +2,17 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct Build {
+    #[serde(rename = "@number")]
     pub number: String,
+    #[serde(rename = "@version")]
     pub version: String,
-    #[serde(rename = "fullNumber")]
+    #[serde(rename = "@fullNumber")]
     pub full_number: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct Channel {
+    #[serde(rename = "@id")]
     pub id: String,
     #[serde(rename = "build")]
     pub builds: Vec<Build>,
@@ -17,6 +20,7 @@ pub struct Channel {
 
 #[derive(Deserialize, Debug)]
 pub struct Product {
+    #[serde(rename = "@name")]
     pub name: String,
     #[serde(rename = "channel", default)]
     pub channels: Vec<Channel>,

--- a/crates/jetbrains/src/print.rs
+++ b/crates/jetbrains/src/print.rs
@@ -23,8 +23,8 @@ fn remove_epoch(version: String) -> String {
     splitter.next().unwrap().to_string()
 }
 
-fn print_update(package: &str, version: String, new_version: &str) {
-    if version != new_version {
+fn print_update(package: &str, version: String, new_version: &str, show_all: bool) {
+    if show_all || version != new_version {
         println!("{} {} -> {}", package, version, new_version);
     }
 }
@@ -40,6 +40,7 @@ fn print_jetbrains_update(
     package: &AurPackage,
     product: &Product,
     is_eap: bool,
+    show_all: bool,
 ) {
     let channel = if is_eap {
         product.channels.first().unwrap()
@@ -67,13 +68,14 @@ fn print_jetbrains_update(
         version = remove_package_build(version);
         new_version = &build.version;
     }
-    print_update(&package.name, version, new_version);
+    print_update(&package.name, version, new_version, show_all);
 }
 
 pub fn print_jetbrains_updates(
     products: Vec<Vec<&str>>,
     packages: Vec<AurPackage>,
     repository: JetBrainsRepository,
+    show_all: bool,
 ) {
     products.iter().for_each(|product| {
         print_jetbrains_update(
@@ -85,6 +87,7 @@ pub fn print_jetbrains_updates(
                 .find(|&u| u.name == product[1])
                 .unwrap(),
             product[0].ends_with("eap"),
+            show_all,
         )
     });
 }

--- a/crates/mongodb/Cargo.toml
+++ b/crates/mongodb/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 aur = { path = "../aur" }
 yum = { path = "../yum" }
 
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }

--- a/crates/teamviewer/Cargo.toml
+++ b/crates/teamviewer/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 aur = { path = "../aur" }
 yum = { path = "../yum" }
 
-reqwest = { version = "0.12.15", features = ["gzip", "json"] }
+reqwest = { version = "0.12.19", features = ["gzip", "json"] }

--- a/crates/yum/Cargo.toml
+++ b/crates/yum/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 [dependencies]
 aur = { path = "../aur" }
 
-itertools = "0.14.0"
+itertools = "0.14"
 libflate = "2.1.0"
 reqwest = { version = "0.12.15", features = ["gzip", "json"] }
-semver = "1.0.23"
+semver = "1.0.26"
 serde = { version = "1.0.219", features = ["derive"] }
-serde-xml-rs = "0.7.0"
+serde-xml-rs = "0.8.1"

--- a/crates/yum/src/model.rs
+++ b/crates/yum/src/model.rs
@@ -3,13 +3,13 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct RepositoryLocation {
-    #[serde(default)]
+    #[serde(rename = "@href", default)]
     pub href: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct RepositoryData {
-    #[serde(rename = "type")]
+    #[serde(rename = "@type")]
     pub data_type: String,
     #[serde(rename = "location")]
     pub location: RepositoryLocation,
@@ -24,12 +24,13 @@ pub struct RepositoryMetadata {
 
 #[derive(Deserialize, Debug)]
 pub struct YumVersion {
-    #[serde(rename = "ver")]
+    #[serde(rename = "@ver")]
     pub version: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct YumPackage {
+    #[serde(rename = "@name")]
     pub name: String,
     #[serde(rename = "version")]
     pub versions: Vec<YumVersion>,

--- a/crates/yum/src/print.rs
+++ b/crates/yum/src/print.rs
@@ -1,17 +1,18 @@
 use crate::YumUpdate;
 use aur::AurPackage;
 
-fn print_update(package: &str, version: String, new_version: &str) {
-    if version != new_version {
+fn print_update(package: &str, version: String, new_version: &str, show_all: bool) {
+    if show_all || version != new_version {
         println!("{} {} -> {}", package, version, new_version);
     }
 }
 
-fn print_yum_update(package: &AurPackage, update: &YumUpdate) {
+fn print_yum_update(package: &AurPackage, update: &YumUpdate, show_all: bool) {
     print_update(
         &package.name,
         package.get_package_version(),
         &update.version,
+        show_all,
     );
 }
 
@@ -19,11 +20,13 @@ pub fn print_yum_updates(
     products: Vec<Vec<&str>>,
     packages: Vec<AurPackage>,
     updates: Vec<YumUpdate>,
+    show_all: bool,
 ) {
     products.iter().for_each(|product| {
         print_yum_update(
             packages.iter().find(|&p| p.name == product[0]).unwrap(),
             updates.iter().find(|&u| u.name == product[1]).unwrap(),
+            show_all,
         )
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use aur::fetch_aur_packages;
 use chrome::fetch_chrome_updates;
+use clap::Parser;
 use edge::fetch_edge_updates;
 use futures::join;
 use jetbrains::{fetch_jetbrains_updates, print_jetbrains_updates};
@@ -8,50 +9,74 @@ use reqwest::Error;
 use teamviewer::fetch_teamviewer_updates;
 use yum::{print_yum_updates, YumUpdate};
 
-async fn check_yum_updates(products: Vec<Vec<&str>>, updates: Vec<YumUpdate>) -> Result<(), Error> {
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Only check updates from JetBrains products
+    #[arg(long = "jb")]
+    jetbrains_only: bool,
+
+    /// Only check updates from MongoDB products
+    #[arg(long = "mongo")]
+    mongodb_only: bool,
+
+    /// Only check updates from Google Chrome products
+    #[arg(long = "chrome")]
+    chrome_only: bool,
+
+    /// Show all packages even if versions match
+    #[arg(long = "all")]
+    show_all: bool,
+}
+
+async fn check_yum_updates(
+    products: Vec<Vec<&str>>,
+    updates: Vec<YumUpdate>,
+    show_all: bool,
+) -> Result<(), Error> {
     let packages = fetch_aur_packages(products.iter().map(|p| p[0]).collect()).await?;
-    print_yum_updates(products, packages, updates);
+    print_yum_updates(products, packages, updates, show_all);
     Ok(())
 }
 
-async fn check_chrome_updates() -> Result<(), Error> {
+async fn check_chrome_updates(show_all: bool) -> Result<(), Error> {
     let products = vec![
         vec!["google-chrome", "google-chrome-stable"],
         vec!["google-chrome-beta", "google-chrome-beta"],
         vec!["google-chrome-canary", "google-chrome-canary"],
         vec!["google-chrome-dev", "google-chrome-unstable"],
     ];
-    check_yum_updates(products, fetch_chrome_updates().await?).await?;
+    check_yum_updates(products, fetch_chrome_updates().await?, show_all).await?;
     Ok(())
 }
 
-async fn check_edge_updates() -> Result<(), Error> {
+async fn check_edge_updates(show_all: bool) -> Result<(), Error> {
     let products = vec![
         vec!["microsoft-edge-beta-bin", "microsoft-edge-beta"],
         vec!["microsoft-edge-dev-bin", "microsoft-edge-dev"],
         vec!["microsoft-edge-stable-bin", "microsoft-edge-stable"],
     ];
-    check_yum_updates(products, fetch_edge_updates().await?).await?;
+    check_yum_updates(products, fetch_edge_updates().await?, show_all).await?;
     Ok(())
 }
 
-async fn check_mongodb_updates() -> Result<(), Error> {
+async fn check_mongodb_updates(show_all: bool) -> Result<(), Error> {
     let products = vec![
         vec!["mongodb-bin", "mongodb-org"],
         vec!["mongodb-tools-bin", "mongodb-database-tools"],
         vec!["mongosh-bin", "mongodb-mongosh"],
     ];
-    check_yum_updates(products, fetch_mongodb_updates().await?).await?;
+    check_yum_updates(products, fetch_mongodb_updates().await?, show_all).await?;
     Ok(())
 }
 
-async fn check_teamviewer_updates() -> Result<(), Error> {
+async fn check_teamviewer_updates(show_all: bool) -> Result<(), Error> {
     let products = vec![vec!["teamviewer", "teamviewer"]];
-    check_yum_updates(products, fetch_teamviewer_updates().await?).await?;
+    check_yum_updates(products, fetch_teamviewer_updates().await?, show_all).await?;
     Ok(())
 }
 
-async fn check_jetbrains_updates() -> Result<(), Error> {
+async fn check_jetbrains_updates(show_all: bool) -> Result<(), Error> {
     let jetbrains_products = vec![
         vec!["aqua", "Aqua", "QA-RELEASE-licensing-RELEASE"],
         vec!["aqua-eap", "Aqua", "QA-EAP-licensing-EAP"],
@@ -99,23 +124,57 @@ async fn check_jetbrains_updates() -> Result<(), Error> {
         fetch_jetbrains_updates(),
         fetch_aur_packages(jetbrains_products.iter().map(|p| p[0]).collect())
     );
-    print_jetbrains_updates(jetbrains_products, packages.unwrap(), updates.unwrap());
+    print_jetbrains_updates(
+        jetbrains_products,
+        packages.unwrap(),
+        updates.unwrap(),
+        show_all,
+    );
     Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let (jetbrains_result, chrome_result, edge_result, mongodb_result, teamviewer_result) = join!(
-        check_jetbrains_updates(),
-        check_chrome_updates(),
-        check_edge_updates(),
-        check_mongodb_updates(),
-        check_teamviewer_updates()
-    );
-    jetbrains_result.expect("Cannot fetch JetBrains updates!");
-    edge_result.expect("Cannot fetch Microsoft Edge updates!");
-    chrome_result.expect("Cannot fetch Google Chrome updates!");
-    mongodb_result.expect("Cannot fetch MongoDB updates!");
-    teamviewer_result.expect("Cannot fetch TeamViewer updates!");
+    let args = Args::parse();
+
+    // Count how many flags are set
+    let flags_count = [args.jetbrains_only, args.mongodb_only, args.chrome_only]
+        .iter()
+        .filter(|&&flag| flag)
+        .count();
+
+    // Ensure only one flag is used at a time
+    if flags_count > 1 {
+        eprintln!("Error: Only one of --jb, --mongo, or --chrome can be specified at a time");
+        std::process::exit(1);
+    }
+
+    if args.jetbrains_only {
+        check_jetbrains_updates(args.show_all)
+            .await
+            .expect("Cannot fetch JetBrains updates!");
+    } else if args.mongodb_only {
+        check_mongodb_updates(args.show_all)
+            .await
+            .expect("Cannot fetch MongoDB updates!");
+    } else if args.chrome_only {
+        check_chrome_updates(args.show_all)
+            .await
+            .expect("Cannot fetch Google Chrome updates!");
+    } else {
+        // Check all products if no specific flag is provided
+        let (jetbrains_result, chrome_result, edge_result, mongodb_result, teamviewer_result) = join!(
+            check_jetbrains_updates(args.show_all),
+            check_chrome_updates(args.show_all),
+            check_edge_updates(args.show_all),
+            check_mongodb_updates(args.show_all),
+            check_teamviewer_updates(args.show_all)
+        );
+        jetbrains_result.expect("Cannot fetch JetBrains updates!");
+        edge_result.expect("Cannot fetch Microsoft Edge updates!");
+        chrome_result.expect("Cannot fetch Google Chrome updates!");
+        mongodb_result.expect("Cannot fetch MongoDB updates!");
+        teamviewer_result.expect("Cannot fetch TeamViewer updates!");
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,18 +142,29 @@ async fn main() -> Result<(), Error> {
         // Run only the selected products concurrently
         let mut futures: Vec<(&str, UpdateFuture)> = Vec::new();
         if args.jetbrains {
-            futures.push(("JetBrains", Box::pin(check_jetbrains_updates(args.show_all))));
+            futures.push((
+                "JetBrains",
+                Box::pin(check_jetbrains_updates(args.show_all)),
+            ));
         }
         if args.mongodb {
             futures.push(("MongoDB", Box::pin(check_mongodb_updates(args.show_all))));
         }
         if args.chrome {
-            futures.push(("Google Chrome", Box::pin(check_chrome_updates(args.show_all))));
+            futures.push((
+                "Google Chrome",
+                Box::pin(check_chrome_updates(args.show_all)),
+            ));
         }
 
-        let results = futures::future::join_all(futures.into_iter().map(|(name, future)| async move { (name, future.await) })).await;
+        let results = futures::future::join_all(
+            futures
+                .into_iter()
+                .map(|(name, future)| async move { (name, future.await) }),
+        )
+        .await;
         for (name, result) in results {
-            result.expect(&format!("Cannot fetch updates for {}!", name));
+            result.unwrap_or_else(|_| panic!("Cannot fetch updates for {}!", name));
         }
     } else {
         // Check all products if no specific flag is provided

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,21 +141,18 @@ async fn main() -> Result<(), Error> {
     if args.jetbrains || args.mongodb || args.chrome {
         // Run only the selected products concurrently
         let mut futures: Vec<(&str, UpdateFuture)> = Vec::new();
-        if args.jetbrains {
-            futures.push((
-                "JetBrains",
-                Box::pin(check_jetbrains_updates(args.show_all)),
-            ));
+
+        macro_rules! add_if_enabled {
+            ($flag:expr, $name:expr, $check_fn:expr) => {
+                if $flag {
+                    futures.push(($name, Box::pin($check_fn(args.show_all))));
+                }
+            };
         }
-        if args.mongodb {
-            futures.push(("MongoDB", Box::pin(check_mongodb_updates(args.show_all))));
-        }
-        if args.chrome {
-            futures.push((
-                "Google Chrome",
-                Box::pin(check_chrome_updates(args.show_all)),
-            ));
-        }
+
+        add_if_enabled!(args.jetbrains, "JetBrains", check_jetbrains_updates);
+        add_if_enabled!(args.mongodb, "MongoDB", check_mongodb_updates);
+        add_if_enabled!(args.chrome, "Google Chrome", check_chrome_updates);
 
         let results = futures::future::join_all(
             futures

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,20 +140,20 @@ async fn main() -> Result<(), Error> {
     let args = Args::parse();
     if args.jetbrains || args.mongodb || args.chrome {
         // Run only the selected products concurrently
-        let mut futures: Vec<UpdateFuture> = Vec::new();
+        let mut futures: Vec<(&str, UpdateFuture)> = Vec::new();
         if args.jetbrains {
-            futures.push(Box::pin(check_jetbrains_updates(args.show_all)));
+            futures.push(("JetBrains", Box::pin(check_jetbrains_updates(args.show_all))));
         }
         if args.mongodb {
-            futures.push(Box::pin(check_mongodb_updates(args.show_all)));
+            futures.push(("MongoDB", Box::pin(check_mongodb_updates(args.show_all))));
         }
         if args.chrome {
-            futures.push(Box::pin(check_chrome_updates(args.show_all)));
+            futures.push(("Google Chrome", Box::pin(check_chrome_updates(args.show_all))));
         }
 
-        let results = futures::future::join_all(futures).await;
-        for result in results {
-            result.expect("Cannot fetch updates!");
+        let results = futures::future::join_all(futures.into_iter().map(|(name, future)| async move { (name, future.await) })).await;
+        for (name, result) in results {
+            result.expect(&format!("Cannot fetch updates for {}!", name));
         }
     } else {
         // Check all products if no specific flag is provided


### PR DESCRIPTION
## Summary
- Add `--jb`, `--mongo`, `--chrome` flags to check specific products
- Add `--all`/`-a` flag to show all packages even when versions match
- Flags are combinable (e.g., `--jb --chrome` checks both)
- Maintain concurrent execution for performance

## Test plan
- [ ] Run `cargo run -- --help` to see new options
- [ ] Test individual flags: `--jb`, `--mongo`, `--chrome`
- [ ] Test combined flags: `--jb --chrome`, `--mongo --chrome`, etc.
- [ ] Test `--all` flag shows packages with matching versions
- [ ] Verify no flags still checks all products
- [ ] Run `cargo fmt` and `cargo clippy`

🤖 Generated with [Claude Code](https://claude.ai/code)